### PR TITLE
Fix potential `_channel` `UnboundLocalError`

### DIFF
--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -200,6 +200,7 @@ class Connection(object):
     @contextmanager
     def _sftp_channel(self, keepalive=False):
         '''Establish new SFTP channel.'''
+        _channel = None
         try:
             _channel = SFTPClient.from_transport(self._transport)
 
@@ -215,7 +216,7 @@ class Connection(object):
         except Exception as err:
             raise err
         finally:
-            if not keepalive:
+            if not keepalive and _channel:
                 _channel.close()
 
     def _start_transport(self, host, port):


### PR DESCRIPTION
Sometimes when assigning to `_channel`, an exception can occur in `SFTPClient.from_transport()`. Because `_channel` doesn't exist if that happens, it causes a second exception when trying to call `close()` in the `finally` block. Assign to the variable outside the `try` block initially so that this exception can't happen in the future. Also make sure that `_channel` is not `None` before we try to close it to account for it being sometimes `None`.