### PR TITLE
Add support to use a single channel for all commands. Some servers do…

### DIFF
--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -219,7 +219,9 @@ class Connection(object):
 
                 if self._default_path is not None:
                     _channel.chdir(self._default_path)
-                    log.info(f'Current Working Directory: [{self._default_path}]')
+                    log.info(
+                        f'Current Working Directory: [{self._default_path}]'
+                    )
 
                 yield _channel
             except Exception as err:


### PR DESCRIPTION
Certain SFTP server do not allow to open a channel for every command. The original pysftp used a single channel for all actions. I've added a flag to allow us to work in a similar way, while by default keeping the new behavior.

Those servers will simply close the connection on the second command issued and it makes sftpretty not very useful with these old(er) SFTP servers.