### PR TITLE
Use warnings.warn instead of raising UserWarning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -11,3 +11,4 @@ Acknowledgment
     * paramiko by Robey Pointer
     * pysftp by dundeemt
     * ssh.py by Zeth
+    * PR #19 by coreyhartley

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -5,6 +5,7 @@ Authors
 
 Acknowledgment
 --------------
+    * PR #19 by coreyhartley
     * PR #15 by RobertCochran
     * PR #12 by erans
     * ftpretty by codebynumbers

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -12,4 +12,3 @@ Acknowledgment
     * paramiko by Robey Pointer
     * pysftp by dundeemt
     * ssh.py by Zeth
-    * PR #19 by coreyhartley

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,7 +1,12 @@
 Change Log
 ==========
 
-1.0.5 (current, released 2022-11-29)
+1.0.6 (current, released 2023-01-15)
+------------------------------------
+    * allow CnOpts knownhost to be set to None directly
+    * standardize on using is for None checks 
+
+1.0.5 (released 2022-11-29)
 ------------------------------------
     * added log_level to connection options
     * added compression security option for Transport
@@ -23,8 +28,8 @@ Change Log
 
 1.0.2 (released 2022-09-09)
 ---------------------------
-    * bug fix for typo in put_d()
     * added sort to localtree() for test continuity
+    * bug fix for typo in put_d()
 
 1.0.1 (released 2022-07-22)
 ---------------------------

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ DESCRIPTION = "Pretty secure file transfer made easy."
 
 setup(
     name='sftpretty',
-    version='1.0.5',
+    version='1.0.6',
 
     packages=['sftpretty', ],
 

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -67,17 +67,22 @@ class CnOpts(object):
                           'rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ssh-dss')
         self.log = False
         self.log_level = 'info'
-        try:
-            self.hostkeys.load(Path(knownhosts).absolute().as_posix())
-        except FileNotFoundError:
-            # no known_hosts in the default unix location, windows has none
-            raise UserWarning((f'No file or host key found in [{knownhosts}]. '
-                               'You will need to explicitly load host keys '
-                               '(cnopts.hostkeys.load(filename)) or disable '
-                               'host key checking (cnopts.hostkeys = None).'))
+
+        if knownhosts is not None:
+            try:
+                self.hostkeys.load(Path(knownhosts).resolve().as_posix())
+            except FileNotFoundError:
+                # no known_hosts in the default unix location, windows has none
+                raise UserWarning((f'No file or host key found in [{knownhosts'
+                                   '}]. You will need to explicitly load host '
+                                   'keys (cnopts.hostkeys.load(filename)) or '
+                                   'disable host key verification (cnopts.'
+                                   'hostkeys = None).'))
+            else:
+                if len(self.hostkeys.items()) == 0:
+                    raise HostKeysException('No host keys found!')
         else:
-            if len(self.hostkeys.items()) == 0:
-                raise HostKeysException('No host keys found!')
+            self.hostkeys = None
 
     def get_hostkey(self, host):
         '''Return the matching known hostkey to be used for verification or
@@ -340,10 +345,10 @@ class Connection(object):
         def _get(self, remotefile, localpath=None, callback=None,
                  preserve_mtime=False):
 
-            if not localpath:
+            if localpath is None:
                 localpath = Path(remotefile).name
 
-            if not callback:
+            if callback is None:
                 callback = partial(_callback, remotefile, logger=logger)
 
             with self._sftp_channel() as channel:
@@ -400,7 +405,7 @@ class Connection(object):
             Path(localdir).mkdir(exist_ok=True, parents=True)
             logger.info(f'Creating Folder [{localdir}]!')
 
-        if not pattern:
+        if pattern is None:
             paths = [
                      (Path(remotedir).joinpath(attribute.filename).as_posix(),
                       Path(localdir).joinpath(attribute.filename).as_posix(),
@@ -530,7 +535,7 @@ class Connection(object):
                logger=logger, silent=silent)
         def _getfo(self, remotefile, flo, callback=None):
 
-            if not callback:
+            if callback is None:
                 callback = partial(_callback, remotefile, logger=logger)
 
             with self._sftp_channel() as channel:
@@ -581,10 +586,10 @@ class Connection(object):
         def _put(self, localfile, remotepath=None, callback=None,
                  confirm=True, preserve_mtime=False):
 
-            if not remotepath:
+            if remotepath is None:
                 remotepath = Path(localfile).name
 
-            if not callback:
+            if callback is None:
                 callback = partial(_callback, localfile, logger=logger)
 
             if preserve_mtime:
@@ -771,10 +776,10 @@ class Connection(object):
         def _putfo(self, flo, remotepath=None, file_size=0, callback=None,
                    confirm=True):
 
-            if not remotepath:
+            if remotepath is None:
                 remotepath = Path(flo.name).name
 
-            if not callback:
+            if callback is None:
                 callback = partial(_callback, flo, logger=logger)
 
             with self._sftp_channel() as channel:

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -73,9 +73,9 @@ class CnOpts(object):
         except FileNotFoundError:
             # no known_hosts in the default unix location, windows has none
             warn(f'No file or host key found in [{knownhosts}]. You will '
-                  'need to explicitly load host keys '
-                  '(cnopts.hostkeys.load(filename)) or disable host key '
-                  'checking (cnopts.hostkeys = None).', UserWarning)
+                 'need to explicitly load host keys '
+                 '(cnopts.hostkeys.load(filename)) or disable host key '
+                 'checking (cnopts.hostkeys = None).', UserWarning)
         else:
             if len(self.hostkeys.items()) == 0:
                 raise HostKeysException('No host keys found!')

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -74,11 +74,12 @@ class CnOpts(object):
                 self.hostkeys.load(Path(knownhosts).resolve().as_posix())
             except FileNotFoundError:
                 # no known_hosts in the default unix location, windows has none
-                raise UserWarning((f'No file or host key found in [{knownhosts'
-                                   '}]. You will need to explicitly load host '
-                                   'keys (cnopts.hostkeys.load(filename)) or '
-                                   'disable host key verification (cnopts.'
-                                   'hostkeys = None).'))
+                raise UserWarning(
+                    f'No file or host key found in [{knownhosts}]. '
+                    'You will need to explicitly load host keys '
+                    '(cnopts.hostkeys.load(filename)) or disable host '
+                    'key verification (cnopts.hostkeys = None).'
+                )
             else:
                 if len(self.hostkeys.items()) == 0:
                     raise HostKeysException('No host keys found!')

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -16,6 +16,7 @@ from socket import gaierror
 from stat import S_ISDIR, S_ISREG
 from tempfile import mkstemp
 from uuid import uuid4
+from warnings import warn
 
 
 class CnOpts(object):
@@ -71,10 +72,10 @@ class CnOpts(object):
             self.hostkeys.load(Path(knownhosts).absolute().as_posix())
         except FileNotFoundError:
             # no known_hosts in the default unix location, windows has none
-            raise UserWarning((f'No file or host key found in [{knownhosts}]. '
-                               'You will need to explicitly load host keys '
-                               '(cnopts.hostkeys.load(filename)) or disable '
-                               'host key checking (cnopts.hostkeys = None).'))
+            warn(f'No file or host key found in [{knownhosts}]. You will '
+                  'need to explicitly load host keys '
+                  '(cnopts.hostkeys.load(filename)) or disable host key '
+                  'checking (cnopts.hostkeys = None).', UserWarning)
         else:
             if len(self.hostkeys.items()) == 0:
                 raise HostKeysException('No host keys found!')

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -16,7 +16,6 @@ from socket import gaierror
 from stat import S_ISDIR, S_ISREG
 from tempfile import mkstemp
 from uuid import uuid4
-from warnings import warn
 
 
 class CnOpts(object):

--- a/tests/test_remote_server_key.py
+++ b/tests/test_remote_server_key.py
@@ -25,14 +25,14 @@ def test_remote_server_key(sftpserver):
 
 def test_cnopts_no_knownhosts():
     '''test setting knownhosts to a non-existant file'''
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         CnOpts(knownhosts='i-m-not-there')
 
 
 def test_cnopts_bad_knownhosts():
     '''test setting knownhosts to a not understood file'''
     with pytest.raises(HostKeysException):
-        with pytest.raises(UserWarning):
+        with pytest.warns(UserWarning):
             knownhosts = Path('~/knownhosts').expanduser().as_posix()
             Path(knownhosts).touch(mode=0o600)
             CnOpts(knownhosts=knownhosts)

--- a/tests/test_remote_server_key.py
+++ b/tests/test_remote_server_key.py
@@ -45,7 +45,7 @@ def test_cnopts_none_knownhosts():
     if Path(knownhosts).exists():
         Path(knownhosts).unlink()
     cnopts = CnOpts(knownhosts=None)
-    assert isinstance(cnopts.hostkeys, None)
+    assert cnopts.hostkeys is None
 
 
 def test_hostkey_not_found():

--- a/tests/test_remote_server_key.py
+++ b/tests/test_remote_server_key.py
@@ -26,7 +26,7 @@ def test_remote_server_key(sftpserver):
 def test_cnopts_bad_knownhosts():
     '''test setting knownhosts to a not understood file'''
     with pytest.raises(HostKeysException):
-        with pytest.warns(UserWarning):
+        with pytest.raises(UserWarning):
             knownhosts = Path('~/knownhosts').expanduser().as_posix()
             Path(knownhosts).touch(mode=0o600)
             CnOpts(knownhosts=knownhosts)

--- a/tests/test_remote_server_key.py
+++ b/tests/test_remote_server_key.py
@@ -23,12 +23,6 @@ def test_remote_server_key(sftpserver):
             hks.save('sftpserver.pub')
 
 
-def test_cnopts_no_knownhosts():
-    '''test setting knownhosts to a non-existant file'''
-    with pytest.raises(UserWarning):
-        CnOpts(knownhosts='i-m-not-there')
-
-
 def test_cnopts_bad_knownhosts():
     '''test setting knownhosts to a not understood file'''
     with pytest.raises(HostKeysException):
@@ -37,6 +31,21 @@ def test_cnopts_bad_knownhosts():
             Path(knownhosts).touch(mode=0o600)
             CnOpts(knownhosts=knownhosts)
             Path(knownhosts).unlink()
+
+
+def test_cnopts_no_knownhosts():
+    '''test setting knownhosts to a non-existant file'''
+    with pytest.raises(UserWarning):
+        CnOpts(knownhosts='i-m-not-there')
+
+
+def test_cnopts_none_knownhosts():
+    '''test setting knownhosts to None for those with no default known_hosts'''
+    knownhosts = Path('~/.ssh/known_hosts').expanduser().as_posix()
+    if Path(knownhosts).exists():
+        Path(knownhosts).unlink()
+    cnopts = CnOpts(knownhosts=None)
+    assert isinstance(cnopts.hostkeys, None)
 
 
 def test_hostkey_not_found():


### PR DESCRIPTION
I've recently replaced this dependency with `pysftp` in a repo of ours.  In our code we do the following:
```
self.cnopts = CnOpts()
self.cnopts.hostkeys = None
```
This causes the follwing error in our tests:
![sftpretty_error](https://user-images.githubusercontent.com/83661242/211920349-71f4243a-9083-4049-b5a8-63ed44f48cd8.png)

The issue is that we cannot set `cnopts.hostkeys = None` due to the `UserWarning` being raised in the constructor, therefore not allowing us to create the object in the first place.  In order to rectify this, I have updated the use of raising `UserWarning` to fire `warnings.warn` instead.  This should ensure that this warning message will not break the constructor going forward.  

Note that in my repo, ubuntu's python 3.6 was unble to be found in the cache.  Not sure what needs to be done there.