### PR TITLE
Update localtree and remotetree functionality

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Change Log
 ------------------------------------
     * remotetree no longer adds entire remote path when joining paths
     * localtree no longer adds entire local path when joining paths
+    * bumped paramiko dependency to 2.9.2 for rsa-sh2 support
 
 1.0.7 (released 2023-02-27)
 ------------------------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,7 +1,12 @@
 Change Log
 ==========
 
-1.0.7 (current, released 2023-02-27)
+1.0.8 (current, released 2023-03-27)
+------------------------------------
+    * remotetree no longer adds entire remote path when joining paths
+    * localtree no longer adds entire local path when joining paths
+
+1.0.7 (released 2023-02-27)
 ------------------------------------
     * fix reversion in put_d
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -416,46 +416,41 @@ after the operation.
 :meth:`sftpretty.Connection.remotetree`
 ----------------------------------
 Is a powerful method that can recursively (*default*) walk a **remote**
-directory structure and calls a user-supplied container (dictionary) where
-entries are stored in ``{directory: tuple(sub-directories, localdir)}`` form.
-It is used in the get_r method of sftpretty and can be used with great effect
-to grab whole directories in parallel.
+directory structure where entries are stored in
+``[tuple(sub-directories, localdir)]`` form. It is used in the get_r method
+of sftpretty and can be used with great effect to grab whole directories in
+parallel.
 
 .. code-block:: python
 
     import sftpretty
     >>> with sftpretty.Connection('hostname', username='me', password='secret') as sftp:
-            directories = {}
-            sftp.remotetree(directories, '/', '/tmp')
+            directories = sftp.remotetree('/', '/', '/tmp')
     >>> directories
-    {'/': [('/archives', '/tmp/archives'),
-           ('/incoming', '/tmp/incoming'),
-           ('/outgoing', '/tmp/outgoing')
-          ],
-     '/incoming': [('/incoming/amrs', '/tmp/incoming/amrs'),
-                   ('/incoming/ffopc', '/tmp/incoming/ffopc'),
-                   ('/incoming/gpb', '/tmp/incoming/gpb'),
-                   ('/incoming/mgmp', '/tmp/incoming/mgmp'),
-                   ('/incoming/temp', '/tmp/incoming/temp')
-                  ]
-    }
+    [('/archives', '/tmp/archives'),
+     ('/incoming', '/tmp/incoming'),
+     ('/outgoing', '/tmp/outgoing')
+    ],
+    [('/incoming/amrs', '/tmp/incoming/amrs'),
+     ('/incoming/ffopc', '/tmp/incoming/ffopc'),
+     ('/incoming/gpb', '/tmp/incoming/gpb'),
+     ('/incoming/mgmp', '/tmp/incoming/mgmp'),
+     ('/incoming/temp', '/tmp/incoming/temp')
+    ]
 
 :attr:`sftpretty.localtree`
 -----------------------
 Is similar to :meth:`pysftp.Connection.remotetree` except that it walks a **local**
-directory structure. It has the same output and likewise needs a user-supplied
-container (dictionary) to store results.
+directory structure. It has the same output.
 
 .. code-block:: python
 
     import sftpretty
-    >>> directories = {}
-    >>> sftpretty.localtree(directories, '/home/user/downloads', '/tmp')
+    >>> directories = sftpretty.localtree('/home/user/downloads', '/home/user/downloads', '/tmp')
     >>> directories
-    {'/home/user/downloads': [('/home/user/downloads/percona', '/tmp/home/user/downloads/percona'),
-                              ('/home/user/downloads/wallstreet', '/tmp/home/user/downloads/wallstreet')
-                             ]
-    }
+    [('/home/user/downloads/percona', '/tmp/percona'),
+     ('/home/user/downloads/wallstreet', '/tmp/wallstreet')
+    ]
 
 :attr:`sftpretty.Connection.sftp_client`
 -------------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ babel
 docutils
 ecdsa
 jinja2
-paramiko>=1.17.0
+paramiko>=2.9.2
 pep8
 pygments
 pylint

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -11,7 +11,7 @@ from paramiko import (hostkeys, SFTPClient, Transport,
 from pathlib import Path, PurePath, PureWindowsPath
 from sftpretty.exceptions import (CredentialException, ConnectionException,
                                   HostKeysException, LoggingException)
-from sftpretty.helpers import _callback, localtree, retry
+from sftpretty.helpers import _callback, hash, localtree, retry, st_mode_to_int
 from socket import gaierror
 from stat import S_ISDIR, S_ISREG
 from tempfile import mkstemp

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -487,22 +487,19 @@ class Connection(object):
         :raises: Any exception raised by operations will be passed through.
         '''
         self.chdir(remotedir)
-
-        directories = {}
         cwd = self._default_path
 
-        directories[cwd] = [(cwd, Path(localdir).joinpath(
-                                       cwd.lstrip('/')).as_posix())]
-
-        self.remotetree(directories, cwd, localdir, recurse=True)
+        directories = [(cwd, localdir)]
+        directories += self.remotetree(cwd, cwd, localdir)
         log.debug(f'Remote Tree: [{directories}]')
 
-        for tld in directories.keys():
-            for remote, local in directories[tld]:
-                self.get_d(remote, local, callback=callback,
-                           pattern=pattern, preserve_mtime=preserve_mtime,
-                           exceptions=exceptions, tries=tries, backoff=backoff,
-                           delay=delay, logger=logger, silent=silent)
+        for remote, local in directories:
+            self.get_d(
+                remote, local, callback=callback,
+                pattern=pattern, preserve_mtime=preserve_mtime,
+                exceptions=exceptions, tries=tries, backoff=backoff,
+                delay=delay, logger=logger, silent=silent
+            )
 
     def getfo(self, remotefile, flo, callback=None, exceptions=None,
               tries=None, backoff=2, delay=1, logger=getLogger(__name__),
@@ -729,19 +726,17 @@ class Connection(object):
         :raises IOError: if remotedir doesn't exist
         :raises OSError: if localdir doesn't exist
         '''
-        directories = {}
-        directories['root'] = [(localdir,
-                                Path(remotedir).joinpath(localdir).as_posix())]
-
-        localtree(directories, localdir, remotedir, recurse=True)
+        directories = [(localdir, remotedir)]
+        directories += localtree(directories, localdir, remotedir)
         log.debug(f'Local Tree: [{directories}]')
 
-        for tld in directories.keys():
-            for local, remote in directories[tld]:
-                self.put_d(local, remote, callback=callback, confirm=confirm,
-                           preserve_mtime=preserve_mtime,
-                           exceptions=exceptions, tries=tries, backoff=backoff,
-                           delay=delay, logger=logger, silent=silent)
+        for local, remote in directories:
+            self.put_d(
+                local, remote, callback=callback, confirm=confirm,
+                preserve_mtime=preserve_mtime,
+                exceptions=exceptions, tries=tries, backoff=backoff,
+                delay=delay, logger=logger, silent=silent
+            )
 
     def putfo(self, flo, remotepath=None, file_size=0, callback=None,
               confirm=True, exceptions=None, tries=None, backoff=2,

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -11,7 +11,7 @@ from paramiko import (hostkeys, SFTPClient, Transport,
 from pathlib import Path, PurePath, PureWindowsPath
 from sftpretty.exceptions import (CredentialException, ConnectionException,
                                   HostKeysException, LoggingException)
-from sftpretty.helpers import _callback, hash, localtree, retry, st_mode_to_int
+from sftpretty.helpers import _callback, localtree, retry
 from socket import gaierror
 from stat import S_ISDIR, S_ISREG
 from tempfile import mkstemp

--- a/tests/test_get_r.py
+++ b/tests/test_get_r.py
@@ -12,22 +12,15 @@ def test_get_r(sftpserver):
         with Connection(**conn(sftpserver)) as sftp:
             localpath = Path(mkdtemp()).as_posix()
             sftp.get_r('.', localpath)
-
-            local_tree = {}
-            remote_tree = {}
-
             remote_cwd = sftp.pwd
-            local_cwd = Path(localpath).joinpath(
-                             remote_cwd.lstrip('/')).as_posix()
 
-            localtree(local_tree, local_cwd, localpath)
-            sftp.remotetree(remote_tree, remote_cwd, localpath)
+            local_tree = localtree(localpath, localpath, remote_cwd)
+            remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
 
-            localdirs = sorted([localdir.replace(localpath, '')
-                                for localdir in local_tree.keys()])
-            remotedirs = sorted(remote_tree.keys())
-
-            assert localdirs == remotedirs
+            assert len(local_tree) == len(remote_tree)
+            for i in range(0, len(local_tree)):
+                assert local_tree[i][0] == remote_tree[i][1]
+                assert local_tree[i][1] == remote_tree[i][0]
 
             # cleanup local
             rmdir(localpath)
@@ -39,22 +32,15 @@ def test_get_r_pwd(sftpserver):
         with Connection(**conn(sftpserver)) as sftp:
             localpath = Path(mkdtemp()).as_posix()
             sftp.get_r('pub/foo2', localpath)
-
-            local_tree = {}
-            remote_tree = {}
-
             remote_cwd = sftp.pwd
-            local_cwd = Path(localpath).joinpath(
-                             remote_cwd.lstrip('/')).as_posix()
 
-            localtree(local_tree, local_cwd, localpath)
-            sftp.remotetree(remote_tree, remote_cwd, localpath)
+            local_tree = localtree(localpath, localpath, remote_cwd)
+            remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
 
-            localdirs = sorted([localdir.replace(localpath, '')
-                                for localdir in local_tree.keys()])
-            remotedirs = sorted(remote_tree.keys())
-
-            assert localdirs == remotedirs
+            assert len(local_tree) == len(remote_tree)
+            for i in range(0, len(local_tree)):
+                assert local_tree[i][0] == remote_tree[i][1]
+                assert local_tree[i][1] == remote_tree[i][0]
 
             # cleanup local
             rmdir(localpath)
@@ -67,23 +53,20 @@ def test_get_r_pathed(sftpserver):
             sftp.chdir('pub/foo2')
             localpath = Path(mkdtemp()).as_posix()
             sftp.get_r('./bar1', localpath)
-
-            local_tree = {}
-            remote_tree = {}
-
             remote_cwd = sftp.pwd
-            local_cwd = Path(localpath).joinpath(
-                             remote_cwd.lstrip('/')).as_posix()
 
-            localtree(local_tree, local_cwd, localpath)
-            sftp.remotetree(remote_tree, remote_cwd, localpath)
+            local_tree = localtree(localpath, localpath, remote_cwd)
+            remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
 
-            actual = hash(Path(local_cwd).joinpath('bar1/bar1.txt').as_posix())
+            actual = hash(Path(localpath).joinpath('bar1/bar1.txt').as_posix())
             expected = ('a69f73cca23a9ac5c8b567dc185a756e97c982164fe258'
                         '59e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3a'
                         'c558f500199d95b6d3e301758586281dcd26')
 
-            assert local_tree.keys() == remote_tree.keys()
+            assert len(local_tree) == len(remote_tree)
+            for i in range(0, len(local_tree)):
+                assert local_tree[i][0] == remote_tree[i][1]
+                assert local_tree[i][1] == remote_tree[i][0]
             assert actual == expected
 
             # cleanup local
@@ -97,22 +80,15 @@ def test_get_r_cdd(sftpserver):
             localpath = Path(mkdtemp()).as_posix()
             sftp.chdir('pub/foo2')
             sftp.get_r('.', localpath)
-
-            local_tree = {}
-            remote_tree = {}
-
             remote_cwd = sftp.pwd
-            local_cwd = Path(localpath).joinpath(
-                             remote_cwd.lstrip('/')).as_posix()
 
-            localtree(local_tree, local_cwd, localpath)
-            sftp.remotetree(remote_tree, remote_cwd, localpath)
+            local_tree = localtree(localpath, localpath, remote_cwd)
+            remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
 
-            localdirs = sorted([localdir.replace(localpath, '')
-                                for localdir in local_tree.keys()])
-            remotedirs = sorted(remote_tree.keys())
-
-            assert localdirs == remotedirs
+            assert len(local_tree) == len(remote_tree)
+            for i in range(0, len(local_tree)):
+                assert local_tree[i][0] == remote_tree[i][1]
+                assert local_tree[i][1] == remote_tree[i][0]
 
             # cleanup local
             rmdir(localpath)

--- a/tests/test_get_r.py
+++ b/tests/test_get_r.py
@@ -15,7 +15,9 @@ def test_get_r(sftpserver):
             remote_cwd = sftp.pwd
 
             local_tree = localtree(localpath, localpath, remote_cwd)
+            local_tree.sort()
             remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
+            remote_tree.sort()
 
             assert len(local_tree) == len(remote_tree)
             for i in range(0, len(local_tree)):
@@ -35,7 +37,9 @@ def test_get_r_pwd(sftpserver):
             remote_cwd = sftp.pwd
 
             local_tree = localtree(localpath, localpath, remote_cwd)
+            local_tree.sort()
             remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
+            remote_tree.sort()
 
             assert len(local_tree) == len(remote_tree)
             for i in range(0, len(local_tree)):
@@ -56,7 +60,9 @@ def test_get_r_pathed(sftpserver):
             remote_cwd = sftp.pwd
 
             local_tree = localtree(localpath, localpath, remote_cwd)
+            local_tree.sort()
             remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
+            remote_tree.sort()
 
             actual = hash(Path(localpath).joinpath('bar1/bar1.txt').as_posix())
             expected = ('a69f73cca23a9ac5c8b567dc185a756e97c982164fe258'
@@ -83,7 +89,9 @@ def test_get_r_cdd(sftpserver):
             remote_cwd = sftp.pwd
 
             local_tree = localtree(localpath, localpath, remote_cwd)
+            local_tree.sort()
             remote_tree = sftp.remotetree(remote_cwd, remote_cwd, localpath)
+            remote_tree.sort()
 
             assert len(local_tree) == len(remote_tree)
             for i in range(0, len(local_tree)):

--- a/tests/test_localtree.py
+++ b/tests/test_localtree.py
@@ -14,25 +14,16 @@ def test_localtree(sftpserver):
             sftp.get_r('.', localpath)
 
             cwd = sftp.pwd
-            directories = {}
+            directories = localtree(localpath, localpath, cwd)
+            dvalues = [
+                (f'{localpath}/pub', f'{cwd}/pub'),
+                (f'{localpath}/pub/foo1', f'{cwd}/pub/foo1'),
+                (f'{localpath}/pub/foo2', f'{cwd}/pub/foo2'),
+                (f'{localpath}/pub/foo2/bar1', f'{cwd}/pub/foo2/bar1')
+            ]
 
-            localtree(directories, localpath + cwd, Path(localpath).anchor)
-
-            dkeys = [f'{localpath}/home/test',
-                     f'{localpath}/home/test/pub',
-                     f'{localpath}/home/test/pub/foo2']
-
-            dvalues = [[(f'{localpath}/home/test/pub',
-                         f'{localpath}/home/test/pub')],
-                       [(f'{localpath}/home/test/pub/foo1',
-                         f'{localpath}/home/test/pub/foo1'),
-                        (f'{localpath}/home/test/pub/foo2',
-                         f'{localpath}/home/test/pub/foo2')],
-                       [(f'{localpath}/home/test/pub/foo2/bar1',
-                         f'{localpath}/home/test/pub/foo2/bar1')]]
-
-            assert sorted(directories.keys()) == dkeys
-            assert sorted(directories.values()) == dvalues
+            assert len(directories) == len(dvalues)
+            assert sorted(directories) == sorted(dvalues)
 
     # cleanup local
     rmdir(localpath)
@@ -47,18 +38,12 @@ def test_localtree_no_recurse(sftpserver):
             sftp.get_r('.', localpath)
 
             cwd = sftp.pwd
-            directories = {}
+            directories = localtree(localpath, localpath, cwd, recurse=False)
+            dvalues = [
+                (f'{localpath}/bar1', f'{cwd}/bar1')
+            ]
 
-            localtree(directories, localpath + cwd, Path(localpath).anchor,
-                      recurse=False)
-
-            dkeys = [f'{localpath}/home/test/pub/foo2']
-
-            dvalues = [[(f'{localpath}/home/test/pub/foo2/bar1',
-                         f'{localpath}/home/test/pub/foo2/bar1')]]
-
-            assert sorted(directories.keys()) == dkeys
-            assert sorted(directories.values()) == dvalues
+            assert directories == dvalues
 
     # cleanup local
     rmdir(localpath)

--- a/tests/test_remotetree.py
+++ b/tests/test_remotetree.py
@@ -11,25 +11,20 @@ def test_remotetree(sftpserver):
     with sftpserver.serve_content(VFS):
         with Connection(**conn(sftpserver)) as sftp:
             cwd = sftp.pwd
-            directories = {}
             localpath = Path(mkdtemp()).as_posix()
 
-            sftp.remotetree(directories, cwd, localpath)
+            directories = sftp.remotetree(cwd, cwd, localpath)
 
-            dkeys = ['/home/test',
-                     '/home/test/pub',
-                     '/home/test/pub/foo2']
+            dvalues = [
+                (f'{cwd}/pub', f'{localpath}/pub'),
+                (f'{cwd}/pub/foo1', f'{localpath}/pub/foo1'),
+                (f'{cwd}/pub/foo2', f'{localpath}/pub/foo2'),
+                (f'{cwd}/pub/foo2/bar1', f'{localpath}/pub/foo2/bar1'),
+            ]
+            sorted(directories)
 
-            dvalues = [[('/home/test/pub', f'{localpath}/home/test/pub')],
-                       [('/home/test/pub/foo1',
-                         f'{localpath}/home/test/pub/foo1'),
-                        ('/home/test/pub/foo2',
-                         f'{localpath}/home/test/pub/foo2')],
-                       [('/home/test/pub/foo2/bar1',
-                         f'{localpath}/home/test/pub/foo2/bar1')]]
-
-            assert list(directories.keys()) == dkeys
-            assert list(directories.values()) == dvalues
+            assert len(directories) == len(dvalues)
+            assert sorted(directories) == sorted(dvalues)
 
 
 def test_remotetree_no_recurse(sftpserver):
@@ -37,13 +32,10 @@ def test_remotetree_no_recurse(sftpserver):
     with sftpserver.serve_content(VFS):
         with Connection(**conn(sftpserver)) as sftp:
             cwd = sftp.pwd
-            directories = {}
             localpath = Path(mkdtemp()).as_posix()
 
-            sftp.remotetree(directories, cwd, localpath, recurse=False)
+            directories = sftp.remotetree(cwd, cwd, localpath, recurse=False)
+            dvalues = [(f'{cwd}/pub', f'{localpath}/pub')]
 
-            dkeys = ['/home/test']
-            dvalues = [[('/home/test/pub', f'{localpath}/home/test/pub')]]
-
-            assert list(directories.keys()) == dkeys
-            assert list(directories.values()) == dvalues
+            assert len(directories) == len(dvalues)
+            assert sorted(directories) == sorted(dvalues)


### PR DESCRIPTION
In order to resolve [this bug](https://github.com/byteskeptical/sftpretty/issues/28), `localtree` and `remotetree` functionality were changed.  This should siplify the logic, as well as remove the additional directiories added to the paths returned.

The first primary chnage in these functions was to add a "base" directory variable, instead of the "containers" variable, so that the relative path could be removed when joining new folder paths.  The second was returning a list of `tuple`s rather than returning a dictionary of tuples through the parameter.  From what I could see, it should simplify the logic as there was an additional for loop in the `put` functions to traverse the keys.