### PR TITLE
fix wrong compression applied ('none',) when compress = True, but no compression tuple provided to cnopts

### DIFF
--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -450,8 +450,9 @@ class Connection(object):
             log.debug(f'Ciphers: [{ciphers}]')
             # Set compression algorithms
             compression = self._cnopts.compression
-            self._transport.get_security_options().compression = compression
-            log.debug(f'Compression: [{compression}]')
+            if bool(compress) and compression != ('none',):
+                self._transport.get_security_options().compression = compression
+            log.debug(f'Compression: [{self._transport.get_security_options().compression}]')
             # Set connection digests
             digests = self._config.get('macs') or self._cnopts.digests
             _digests = self._transport.get_security_options().digests

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -431,9 +431,6 @@ class Connection(object):
             self._transport.set_keepalive(int(keepalive))
             self._transport.set_log_channel(host)
 
-            compress = self._config.get('compression') or self._cnopts.compress
-            self._transport.use_compression(compress=bool(compress))
-
             # Set disabled algorithms
             disabled_algorithms = self._cnopts.disabled_algorithms
             self._transport.disabled_algorithms = disabled_algorithms
@@ -449,6 +446,9 @@ class Connection(object):
             security_options.ciphers = tuple(
                 cipher for cipher in ciphers if cipher in _ciphers)
             log.debug(f'Ciphers: [{ciphers}]')
+            # Enable/Disable compression
+            compress = self._config.get('compression') or self._cnopts.compress
+            self._transport.use_compression(compress=bool(compress))
             # Set compression algorithms
             compression = self._cnopts.compression
             if bool(compress) and compression != ('none',):

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -440,42 +440,43 @@ class Connection(object):
             log.debug(f'Disabled Algorithms: [{disabled_algorithms}]')
 
             # Security Options
+            security_options = self._transport.get_security_options()
             # Set allowed ciphers
             ciphers = self._config.get('ciphers') or self._cnopts.ciphers
-            _ciphers = self._transport.get_security_options().ciphers
+            _ciphers = security_options.ciphers
             if not isinstance(ciphers, tuple):
                 ciphers = tuple(ciphers.split(','))
-            self._transport.get_security_options().ciphers = tuple(
+            security_options.ciphers = tuple(
                 cipher for cipher in ciphers if cipher in _ciphers)
             log.debug(f'Ciphers: [{ciphers}]')
             # Set compression algorithms
             compression = self._cnopts.compression
             if bool(compress) and compression != ('none',):
-                self._transport.get_security_options().compression = compression
-            log.debug(f'Compression: [{self._transport.get_security_options().compression}]')
+                security_options.compression = compression
+            log.debug(f'Compression: [{security_options.compression}]')
             # Set connection digests
             digests = self._config.get('macs') or self._cnopts.digests
-            _digests = self._transport.get_security_options().digests
+            _digests = security_options.digests
             if not isinstance(digests, tuple):
                 digests = tuple(digests.split(','))
-            self._transport.get_security_options().digests = tuple(
+            security_options.digests = tuple(
                 digest for digest in digests if digest in _digests)
             log.debug(f'MACs: [{digests}]')
             # Set connection kex
             kexs = self._config.get('kexalgorithms') or self._cnopts.kex
-            _kex = self._transport.get_security_options().kex
+            _kex = security_options.kex
             if not isinstance(kexs, tuple):
                 kexs = tuple(kexs.split(','))
-            self._transport.get_security_options().kex = tuple(
+            security_options.kex = tuple(
                 kex for kex in kexs if kex in _kex)
             log.debug(f'KEX: [{kexs}]')
             # Set allowed key types
             key_types = self._config.get('pubkeyacceptedalgorithms') or\
                 self._cnopts.key_types
-            _key_types = self._transport.get_security_options().key_types
+            _key_types = security_options.key_types
             if not isinstance(key_types, tuple):
                 key_types = tuple(key_types.split(','))
-            self._transport.get_security_options().key_types = tuple(
+            security_options.key_types = tuple(
                 key_type for key_type in key_types if key_type in _key_types)
             log.debug(f'Public Key Types: [{key_types}]')
 

--- a/sftpretty/__init__.py
+++ b/sftpretty/__init__.py
@@ -440,6 +440,11 @@ class Connection(object):
             self._transport.set_keepalive(int(keepalive))
             self._transport.set_log_channel(host)
 
+            # Set compression
+            compress = self._config.get('compression') or self._cnopts.compress
+            self._transport.use_compression(compress=bool(compress))
+            log.debug(f'Compress: [{compress}]')
+
             # Set disabled algorithms
             disabled_algorithms = self._cnopts.disabled_algorithms
             self._transport.disabled_algorithms = disabled_algorithms
@@ -455,9 +460,6 @@ class Connection(object):
             security_options.ciphers = tuple(
                 cipher for cipher in ciphers if cipher in _ciphers)
             log.debug(f'Ciphers: [{ciphers}]')
-            # Enable/Disable compression
-            compress = self._config.get('compression') or self._cnopts.compress
-            self._transport.use_compression(compress=bool(compress))
             # Set compression algorithms
             compression = self._cnopts.compression
             if bool(compress) and compression != ('none',):

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,6 +1,6 @@
 '''test sftpretty.compression param'''
 
-from common import LOCAL, SKIP_IF_CI
+from common import LOCAL
 from sftpretty import CnOpts, Connection
 
 
@@ -10,7 +10,6 @@ def test_compression_default():
         assert sftp.active_compression == ('none', 'none')
 
 
-@SKIP_IF_CI
 def test_compression_enabled():
     '''test that compress=True results in compression enabled, assuming
     that the server supports compression'''


### PR DESCRIPTION
In the current version of the code, `test_compression_enabled` fails and it's been disabled in CI tests. I was able to find the issue and implement a fix (also enabled in CI tests).

In the `_start_transport` method, if `cnopts.compress` is True, it calls `self._transport.use_compression(compress=bool(compress))`. This sets the compression options within paramiko Transport -

```py
        if compress:
            self._preferred_compression = ("zlib@openssh.com", "zlib", "none")
        else:
            self._preferred_compression = ("none",)
```
After this step however, if `cnopts.compression` is not provided, it defaults to ("none",), and `_start_transport` method assigns this back into the transport through security options. This resets paramiko's `_preferred_compression` to ("none",) and disables compression. This is effectively equivalent to `self._transport.use_compression(compress=False)`.

It also makes the behavior inaccurate per cnopts docstring which states that the default `cnopts.compression` is `paramiko.Transport.SecurityOptions.compression` 

```py
            compression = self._cnopts.compression
            self._transport.get_security_options().compression = compression
```

The fix is to only set security options compression if cnopts compress is enabled and compression is not the default value ('none',)

```py
            compression = self._cnopts.compression
            if bool(compress) and compression != ('none',):
                self._transport.get_security_options().compression = compression
```


------
Additionally, I have created one instance of security options so the object is not initialized multiple times for each option. This also keeps line width within pep8 recommendations

```py
security_options = self._transport.get_security_options()
```